### PR TITLE
Fixed build file

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,23 +13,10 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Setup JDK cache
-        uses: actions/cache@v2
-        id: jdkcache
-        with:
-          key: ${{ runner.os }}-jdk-${{ hashFiles('**/build.gradle') }}
-          path: |
-            jdk.tar.gz
-
-      - name: Download JDK
-        if: steps.jdkcache.outputs.cache-hit != 'true'
-        run: wget https://download.bell-sw.com/java/14.0.1+8/bellsoft-jdk14.0.1+8-linux-amd64-full.tar.gz -O jdk.tar.gz
-
       - name: Set up JDK 14
         uses: actions/setup-java@v1
         with:
           java-version: 14
-          jdkFile: jdk.tar.gz
 
       - name: Build GWT
         run: ./gradlew html:dist


### PR DESCRIPTION
The only error you had was that the /assets folder wasn't commited so I added a `.gitkeep` file into there.

Additionally, I got rid of the custom jdk setup and switched it to the prepackaged one with the action, therefore you don't need to setup a cache and download one manually.

Hope that helps.

https://lyze237.github.io/ColorInterpolationComparison/